### PR TITLE
Seed test pastes directly to the db

### DIFF
--- a/tests/common/paste_helper.rs
+++ b/tests/common/paste_helper.rs
@@ -1,5 +1,6 @@
-use crate::common::client::TestClient;
+use crate::common::app::TestApp;
 use crate::common::rand_helper;
+use crate::common::user_helper::TestUser;
 use crate::prelude::*;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -27,10 +28,8 @@ impl TestPaste {
         TestPasteBuilder::new()
     }
 
-    pub async fn persist(mut self, client: &TestClient) -> Result<Self> {
-        let response = client.api_pastes().post(&self).await?;
-        let id: Uuid = response.json().await?;
-        self.id = Some(id.to_string());
+    pub async fn seed(self, app: &TestApp, user: &TestUser) -> Result<Self> {
+        app.seed_paste(self.clone(), user).await?;
         Ok(self)
     }
 }
@@ -81,9 +80,10 @@ impl TestPasteBuilder {
         Ok(self.body(rand_helper::random_string(1..=1024)?))
     }
 
-    // This does not set random id or visibility, since that's usually not what we want
+    // This does not set visibility, since that's usually not what we want
     pub fn random(self) -> Result<Self> {
         Ok(self
+            .random_id()
             .random_filename()?
             .random_description()?
             .random_body()?)

--- a/tests/common/user_helper.rs
+++ b/tests/common/user_helper.rs
@@ -5,6 +5,7 @@ use uuid::Uuid;
 
 #[derive(Clone, Debug)]
 pub struct TestUser {
+    pub id: Option<String>,
     pub username: String,
     pub email: String,
     pub password: String,
@@ -22,17 +23,18 @@ impl TestUser {
         TestUserBuilder::new()
     }
 
-    pub async fn seed(self, app: &TestApp) -> Result<Self> {
-        let id = Uuid::now_v7();
-        app.seed_user(id, self.clone()).await?;
+    pub async fn seed(mut self, app: &TestApp) -> Result<Self> {
+        self.id = Some(Uuid::now_v7().to_string());
+        app.seed_user(self.clone()).await?;
         Ok(self)
     }
 
-    pub async fn seed_with_api_key(self, app: &TestApp) -> Result<(Self, String)> {
-        let id = Uuid::now_v7();
+    pub async fn seed_with_api_key(mut self, app: &TestApp) -> Result<(Self, String)> {
+        let id = Uuid::now_v7().to_string();
+        self.id = Some(id.clone());
         let api_key = rand_helper::random_api_key();
-        app.seed_user(id, self.clone()).await?;
-        app.seed_api_key(api_key.clone(), id).await?;
+        app.seed_user(self.clone()).await?;
+        app.seed_api_key(api_key.clone(), &self).await?;
         Ok((self, api_key))
     }
 }
@@ -79,6 +81,7 @@ impl TestUserBuilder {
         let password = self.password.clone().unwrap_or("knight_killer".into());
 
         TestUser {
+            id: None,
             username,
             email,
             password,


### PR DESCRIPTION
Rather than creating them via an api call. This comes with some trade-offs...

Pros:
- It is marginally faster. Test run about 5-7% faster this way.
- Allows for more flexibility in what can be written to the DB. For instance, this allows for pastes with custom uuids that effectively mock time.

Cons:
- Violates the integration testing principle that (as much as possible) we want to treat the app as a black box that we interact with exclusively via an exposed public interface. I think that's probably fine when creating test state.
-  Adds complexity to how test state is created. If a test fails, it might be that the state wasn't seeded correctly, which wouldn't represent a real bug in the app. Whereas when state was created via api call, failures would typically reflect a bug in the app.