### PR TITLE
Switch from the `validator` crate to `garde`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.59",
+ "syn",
 ]
 
 [[package]]
@@ -150,7 +150,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn",
 ]
 
 [[package]]
@@ -253,7 +253,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn",
 ]
 
 [[package]]
@@ -382,6 +382,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
+name = "castaway"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,6 +405,19 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "convert_case"
@@ -502,41 +524,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.20.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.59",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
-dependencies = [
- "darling_core",
- "quote",
- "syn 2.0.59",
-]
-
-[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,7 +543,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.59",
+ "syn",
 ]
 
 [[package]]
@@ -699,6 +686,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "garde"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a44029f2f9359712d0c34cb78dc36266e9949ffbfcc13f5f737f6e6f1a7226"
+dependencies = [
+ "compact_str",
+ "garde_derive",
+ "once_cell",
+ "regex",
+ "smallvec",
+]
+
+[[package]]
+name = "garde_derive"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e2e952fbf2bcd9dae6854d7ebcbfb05f261656d1131f4f1f4fac9da450adec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,6 +748,7 @@ dependencies = [
  "axum-extra",
  "derive_more",
  "dotenvy",
+ "garde",
  "memory-serve",
  "once_cell",
  "rand",
@@ -755,7 +768,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
- "validator",
 ]
 
 [[package]]
@@ -927,12 +939,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,7 +1097,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha256",
- "syn 2.0.59",
+ "syn",
  "tracing",
  "tracing-subscriber",
  "walkdir",
@@ -1262,7 +1268,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn",
 ]
 
 [[package]]
@@ -1323,7 +1329,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn",
 ]
 
 [[package]]
@@ -1369,30 +1375,6 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -1712,7 +1694,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn",
 ]
 
 [[package]]
@@ -1816,26 +1798,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
+name = "static_assertions"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -1932,7 +1904,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn",
 ]
 
 [[package]]
@@ -2017,7 +1989,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn",
 ]
 
 [[package]]
@@ -2124,7 +2096,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn",
 ]
 
 [[package]]
@@ -2232,36 +2204,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "validator"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db79c75af171630a3148bd3e6d7c4f42b6a9a014c2945bc5ed0020cbb8d9478e"
-dependencies = [
- "idna 0.5.0",
- "once_cell",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "url",
- "validator_derive",
-]
-
-[[package]]
-name = "validator_derive"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55591299b7007f551ed1eb79a684af7672c19c3193fb9e0a31936987bb2438ec"
-dependencies = [
- "darling",
- "once_cell",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.59",
-]
-
-[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2325,7 +2267,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -2359,7 +2301,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2586,7 +2528,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ axum = { version = "0.7.5", features = ["macros"] }
 axum-extra = { version = "0.9.3", features = ["cookie"] }
 derive_more = "0.99.18"
 dotenvy = "0.15.7"
+garde = { version = "0.19.2", features = ["email", "derive"] }
 memory-serve = "0.4.5"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
@@ -37,7 +38,6 @@ tower-http = { version = "0.5.2", features = ["trace", "compression-full", "time
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 uuid = { version = "1.8.0", features = ["v7", "fast-rng", "serde"] }
-validator = { version = "0.18.1", features = ["derive"] }
 
 [dev-dependencies]
 once_cell = "1.19.0"

--- a/src/controllers/api/pastes.rs
+++ b/src/controllers/api/pastes.rs
@@ -6,9 +6,9 @@ use crate::models::paste::{Paste, Visibility};
 use axum::extract::{Path, State};
 use axum::response::IntoResponse;
 use axum::Json;
+use garde::Validate;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-use validator::Validate;
 
 #[derive(Serialize)]
 struct IndexResponse {
@@ -37,7 +37,7 @@ pub async fn index(
     Ok(Json(IndexResponse { pastes, pagination }))
 }
 
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, Deserialize)]
 pub struct CreatePaste {
     filename: String,
     description: String,
@@ -84,7 +84,7 @@ pub async fn show_raw(
     }
 }
 
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, Deserialize)]
 pub struct UpdatePaste {
     filename: Option<String>,
     description: Option<String>,

--- a/src/controllers/api/prelude.rs
+++ b/src/controllers/api/prelude.rs
@@ -26,9 +26,7 @@ pub enum Error {
 impl From<ModelsError> for Error {
     fn from(error: ModelsError) -> Self {
         match error {
-            ModelsError::Validation(_) | ModelsError::ParseInt(_) => {
-                Self::BadRequest(Box::new(error))
-            }
+            ModelsError::Garde(_) | ModelsError::ParseInt(_) => Self::BadRequest(Box::new(error)),
             _ => Self::InternalServerError(Box::new(error)),
         }
     }

--- a/src/controllers/pastes.rs
+++ b/src/controllers/pastes.rs
@@ -9,9 +9,9 @@ use crate::views::pastes::{
 use axum::extract::{Form, Path, Query, State};
 use axum::http::{header::HeaderMap, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Redirect};
+use garde::Validate;
 use serde::Deserialize;
 use uuid::Uuid;
-use validator::Validate;
 
 pub async fn index(
     session: Option<Session>,
@@ -50,7 +50,7 @@ pub async fn new(session: Session) -> NewPastesTemplate {
     NewPastesTemplate { session }
 }
 
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, Deserialize)]
 pub struct CreatePaste {
     pub filename: String,
     pub description: String,
@@ -145,7 +145,7 @@ pub async fn edit(
     }
 }
 
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, Deserialize)]
 pub struct UpdatePaste {
     pub filename: String,
     pub description: Option<String>,

--- a/src/controllers/prelude.rs
+++ b/src/controllers/prelude.rs
@@ -27,9 +27,7 @@ pub enum Error {
 impl From<ModelsError> for Error {
     fn from(error: ModelsError) -> Self {
         match error {
-            ModelsError::Validation(_) | ModelsError::ParseInt(_) => {
-                Self::BadRequest(Box::new(error))
-            }
+            ModelsError::Garde(_) | ModelsError::ParseInt(_) => Self::BadRequest(Box::new(error)),
             _ => Self::InternalServerError(Box::new(error)),
         }
     }

--- a/src/controllers/sessions.rs
+++ b/src/controllers/sessions.rs
@@ -9,13 +9,12 @@ use axum::http::{header::HeaderMap, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
 use secrecy::ExposeSecret;
 use serde::Deserialize;
-use validator::Validate;
 
 pub async fn new() -> NewSessionsTemplate {
     NewSessionsTemplate { session: None }
 }
 
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, Deserialize)]
 pub struct CreateSession {
     pub email: String,
     pub password: Password,

--- a/src/controllers/users.rs
+++ b/src/controllers/users.rs
@@ -8,9 +8,9 @@ use axum::body::Body;
 use axum::extract::{Form, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
+use garde::Validate;
 use secrecy::ExposeSecret;
 use serde::Deserialize;
-use validator::Validate;
 
 pub async fn new() -> NewUsersTemplate {
     NewUsersTemplate { session: None }

--- a/src/helpers/pagination.rs
+++ b/src/helpers/pagination.rs
@@ -1,6 +1,6 @@
+use garde::Validate;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-use validator::Validate;
 
 const PER_PAGE_DEFAULT: usize = 10;
 const PER_PAGE_MAX: usize = 100;
@@ -8,9 +8,11 @@ const PER_PAGE_MAX: usize = 100;
 #[derive(Clone, Deserialize, Debug, Validate)]
 pub struct CursorPaginationParams {
     #[serde(default = "CursorPaginationParams::per_page_default")]
-    #[validate(range(min = 1, max = PER_PAGE_MAX))]
+    #[garde(range(min = 1, max = PER_PAGE_MAX))]
     pub per_page: usize,
+    #[garde(skip)]
     pub prev_page: Option<Uuid>,
+    #[garde(skip)]
     pub next_page: Option<Uuid>,
 }
 

--- a/src/models/prelude.rs
+++ b/src/models/prelude.rs
@@ -11,7 +11,7 @@ pub enum Error {
     TokioRusqlite(#[from] tokio_rusqlite::Error),
 
     #[error(transparent)]
-    Validation(#[from] validator::ValidationErrors),
+    Garde(#[from] garde::error::Report),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;


### PR DESCRIPTION
`garde` is at least as well maintained, has better documentation, and also can handle the new type pattern.