### PR TITLE
Fix minor title bug

### DIFF
--- a/src/views/pastes/new.html
+++ b/src/views/pastes/new.html
@@ -1,5 +1,11 @@
 {% extends "base.html" %}
-{% block title %}New Paste{% endblock %}
+{% block title %}
+    {% if session.is_some() %}
+        New Paste
+    {% else %}
+        About Gluestick
+    {% endif %}
+{% endblock %}
 {% block main %}
     {% if let Some(session) = session %}
         <main class="pastes-new">


### PR DESCRIPTION
This makes it so that when logged out and shown the "about" page at the app root, the title correctly says "About Gluestick", rather than "New Paste" (which is correct when logged in and shown the new paste form).