### PR TITLE
Format paste uuids without hyphenation in urls

### DIFF
--- a/src/views/pastes/index.html
+++ b/src/views/pastes/index.html
@@ -8,7 +8,7 @@
                 {% for (paste, username, syntax_highlighted_html) in paste_username_html_triples %}
                     <li class="paste">
                         <div class="filename-bar">
-                            <a href="/{{ username }}">{{ username }}</a> / <a href="{{ username }}/{{ paste.id }}">{{ paste.filename }}</a>
+                            <a href="/{{ username }}">{{ username }}</a> / <a href="{{ username }}/{{ paste.id.as_simple() }}">{{ paste.filename }}</a>
                         </div>
                         {% if !paste.description.is_empty() %}<div class="description-bar">{{ paste.description }}</div>{% endif %}
                         <div class="metadata-bar">

--- a/src/views/pastes/show.html
+++ b/src/views/pastes/show.html
@@ -3,7 +3,7 @@
 {% block main %}
     <main class="pastes-show">
         <h1>
-            <a href="/{{ username }}">{{ username }}</a> / <a href="/{{ username }}/{{ paste.id }}">{{ paste.filename }}</a>
+            <a href="/{{ username }}">{{ username }}</a> / <a href="/{{ username }}/{{ paste.id.as_simple() }}">{{ paste.filename }}</a>
             {% if paste.visibility.is_secret() %}
                 <span class="secret-tag"
                       title="Only people with the link can see this paste">Secret</span>
@@ -16,7 +16,8 @@
                 {{ paste.body|format_byte_size }}
             </div>
             <div class="actions">
-                <a hx-boost="false" href="/{{ username }}/{{ paste.id }}/raw">
+                <a hx-boost="false"
+                   href="/{{ username }}/{{ paste.id.as_simple() }}/raw">
                     <svg class="icon">
                         <use href="/assets/images/vendor/feather-sprite-subset.v4.29.0.svg#code" />
                     </svg>
@@ -28,7 +29,8 @@
                     </svg>
                     Copy
                 </button>
-                <a hx-boost="false" href="/{{ username }}/{{ paste.id }}/download">
+                <a hx-boost="false"
+                   href="/{{ username }}/{{ paste.id.as_simple() }}/download">
                     <svg class="icon">
                         <use href="/assets/images/vendor/feather-sprite-subset.v4.29.0.svg#download" />
                     </svg>
@@ -36,14 +38,14 @@
                 </a>
                 {% if let Some(session) = session %}
                     {% if session.user.id == paste.user_id %}
-                        <a href="/{{ username }}/{{ paste.id }}/edit">
+                        <a href="/{{ username }}/{{ paste.id.as_simple() }}/edit">
                             <svg class="icon">
                                 <use href="/assets/images/vendor/feather-sprite-subset.v4.29.0.svg#edit" />
                             </svg>
                             Edit
                         </a>
                         <button hx-confirm="Are you sure you want to delete this paste?"
-                                hx-delete="/{{ username }}/{{ paste.id }}">
+                                hx-delete="/{{ username }}/{{ paste.id.as_simple() }}">
                             <svg class="icon">
                                 <use href="/assets/images/vendor/feather-sprite-subset.v4.29.0.svg#trash-2" />
                             </svg>

--- a/src/views/users/show.html
+++ b/src/views/users/show.html
@@ -8,7 +8,7 @@
                 {% for (paste, syntax_highlighted_html) in paste_html_pairs %}
                     <li class="paste">
                         <div class="filename-bar">
-                            <a href="/{{ user.username }}">{{ user.username }}</a> / <a href="{{ user.username }}/{{ paste.id }}">{{ paste.filename }}</a>
+                            <a href="/{{ user.username }}">{{ user.username }}</a> / <a href="{{ user.username }}/{{ paste.id.as_simple() }}">{{ paste.filename }}</a>
                             {% if paste.visibility.is_secret() %}
                                 <span class="secret-tag"
                                       title="Only people with the link can see this paste">Secret</span>


### PR DESCRIPTION
The api already is able to parse uuids from various formats with and without hyphenation (and continues to be able to do so). So this was merely a change in how urls are formatted within html that the app returns.