### PR TITLE
Give session tokens a unique id

### DIFF
--- a/src/db/migrations/01-init.sql
+++ b/src/db/migrations/01-init.sql
@@ -12,8 +12,10 @@ CREATE TABLE users (
 ) STRICT;
 
 CREATE TABLE session_tokens (
+  -- id is a UUIDv7
+  id BLOB PRIMARY KEY CHECK(length(id) = 16),
   -- token is a randomly generated u128, formatted as hex, hashed via SHA-256
-  token BLOB PRIMARY KEY CHECK(length(token) = 32),
+  token BLOB NOT NULL CHECK(length(token) = 32),
   -- user_id is a UUIDv7
   user_id BLOB NOT NULL CHECK(length(user_id) = 16),
   -- created_at and last_used_at are both unix timestamps, with millisecond precision


### PR DESCRIPTION
This better matches what we do with API keys and also makes it easier to uniquely identify specific sessions without having to reference the hashed token itself.