### PR TITLE
Upgrade uuid crate from v0.8.0 to v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2234,9 +2234,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4"
 dependencies = [
  "getrandom",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tokio-rusqlite = "0.5.1"
 tower-http = { version = "0.5.2", features = ["compression-full", "timeout", "trace"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-uuid = { version = "1.8.0", features = ["fast-rng", "serde", "v7"] }
+uuid = { version = "1.12.0", features = ["fast-rng", "serde", "v7"] }
 
 [dev-dependencies]
 reqwest = { version = "0.12.7", features = ["cookies", "json"] }

--- a/tests/html_api/paste_tests.rs
+++ b/tests/html_api/paste_tests.rs
@@ -5,9 +5,8 @@ use crate::common::rand_helper::{random_alphanumeric_string, random_filename, ra
 use crate::common::test_app::TestApp;
 use crate::common::test_client::TestClient;
 use crate::prelude::*;
-use jiff::Timestamp as JiffTimestamp;
 use reqwest::header::HeaderValue;
-use uuid::{NoContext, Timestamp, Uuid};
+use uuid::Uuid;
 
 #[tokio::test]
 async fn index_happy_path() -> Result<()> {
@@ -143,17 +142,12 @@ async fn index_paginates_correctly() -> Result<()> {
     let app = TestApp::spawn().await?;
     let user = MockUser::builder().random()?.build().seed(&app).await?;
     let client = TestClient::new(app.address, None)?;
-    let now = (JiffTimestamp::now().as_millisecond()) as u64;
 
     let mut pastes = Vec::new();
-    for i in 0..8 {
+    for _ in 0..8 {
         let paste = MockPaste::builder()
             .random()?
-            // This is necessary because we assert below on the order of items within and across pages.
-            // That order is based on uuid v7 ordering, which has millisecond precision. Our tests are
-            // so fast at creating these pastes that without this sleep, we can get multiple pastes
-            // with the same millisecond of creation, which then fails the ordering assertions.
-            .id(Uuid::new_v7(Timestamp::from_unix(NoContext, now + i, 0)))
+            .id(Uuid::now_v7())
             .build()
             .seed(&app, &user)
             .await?;

--- a/tests/html_api/user_tests.rs
+++ b/tests/html_api/user_tests.rs
@@ -6,8 +6,7 @@ use crate::common::rand_helper::{random_alphanumeric_string, random_filename, ra
 use crate::common::test_app::TestApp;
 use crate::common::test_client::TestClient;
 use crate::prelude::*;
-use jiff::Timestamp as JiffTimestamp;
-use uuid::{NoContext, Timestamp, Uuid};
+use uuid::Uuid;
 
 #[tokio::test]
 async fn signup_happy_path() -> Result<()> {
@@ -531,17 +530,12 @@ async fn show_paginates_correctly() -> Result<()> {
     let app = TestApp::spawn().await?;
     let user = MockUser::builder().random()?.build().seed(&app).await?;
     let client = TestClient::new(app.address, None)?;
-    let now = (JiffTimestamp::now().as_millisecond()) as u64;
 
     let mut pastes = Vec::new();
-    for i in 0..8 {
+    for _ in 0..8 {
         let paste = MockPaste::builder()
             .random()?
-            // This is necessary because we assert below on the order of items within and across pages.
-            // That order is based on uuid v7 ordering, which has millisecond precision. Our tests are
-            // so fast at creating these pastes that without this sleep, we can get multiple pastes
-            // with the same millisecond of creation, which then fails the ordering assertions.
-            .id(Uuid::new_v7(Timestamp::from_unix(NoContext, now + i, 0)))
+            .id(Uuid::now_v7())
             .build()
             .seed(&app, &user)
             .await?;

--- a/tests/json_api/paste_tests.rs
+++ b/tests/json_api/paste_tests.rs
@@ -5,10 +5,9 @@ use crate::common::rand_helper::{random_alphanumeric_string, random_filename, ra
 use crate::common::test_app::TestApp;
 use crate::common::test_client::TestClient;
 use crate::prelude::*;
-use jiff::Timestamp as JiffTimestamp;
 use serde::Deserialize;
 use std::collections::HashSet;
-use uuid::{NoContext, Timestamp, Uuid};
+use uuid::Uuid;
 
 #[derive(Debug, Deserialize)]
 struct IndexResponse {
@@ -168,16 +167,11 @@ async fn index_paginates_correctly() -> Result<()> {
         .seed_with_api_key(&app)
         .await?;
     let client = TestClient::new(app.address, Some(&api_key))?;
-    let now = (JiffTimestamp::now().as_millisecond()) as u64;
 
     let mut pastes = Vec::new();
     for i in 0..8 {
         let paste = MockPaste::builder()
-            // This is necessary because we assert below on the order of items within and across pages.
-            // That order is based on uuid v7 ordering, which has millisecond precision. Our tests are
-            // so fast at creating these pastes that without this sleep, we can get multiple pastes
-            // with the same millisecond of creation, which then fails the ordering assertions.
-            .id(Uuid::new_v7(Timestamp::from_unix(NoContext, now + i, 0)))
+            .id(Uuid::now_v7())
             .filename(i.to_string())
             .description(i.to_string())
             .body(i.to_string())


### PR DESCRIPTION
v0.9.0 introduced guaranteed monotonicity, which simplifies some of the testing code as we can just call `now_v7` in tests and expect the ordering of the calls to be reflected in the resulting uuids, even when the calls happen to all fall on the same millisecond.