### PR TITLE
Upgrade secrecy crate from v0.8.0 to v0.10.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1805,9 +1805,9 @@ dependencies = [
 
 [[package]]
 name = "secrecy"
-version = "0.8.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "serde",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rand = "0.8.5"
 rand_chacha = "0.3.1"
 rusqlite = { version = "0.31.0", features = ["bundled", "uuid"] }
 rusqlite_migration = { version = "1.2.0", features = ["alpha-async-tokio-rusqlite"] }
-secrecy = { version = "0.8.0", features = ["serde"] }
+secrecy = { version = "0.10.3", features = ["serde"] }
 serde = { version = "1.0.209", features = ["derive"] }
 sha2 = "0.10.8"
 syntect = "5.2.0"

--- a/src/controllers/sessions_controller.rs
+++ b/src/controllers/sessions_controller.rs
@@ -7,7 +7,7 @@ use axum::body::Body;
 use axum::extract::{Form, State};
 use axum::http::{header::HeaderMap, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
-use secrecy::{ExposeSecret, Secret};
+use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 
 pub async fn new() -> NewPage {
@@ -17,7 +17,7 @@ pub async fn new() -> NewPage {
 #[derive(Clone, Deserialize)]
 pub struct CreateParams {
     pub email: String,
-    pub password: Secret<String>,
+    pub password: SecretString,
 }
 
 pub async fn create(

--- a/src/controllers/users_controller.rs
+++ b/src/controllers/users_controller.rs
@@ -17,7 +17,7 @@ use axum::extract::{Form, State};
 use axum::extract::{Path, Query};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use secrecy::{ExposeSecret, Secret};
+use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 
 pub async fn new() -> NewPage {
@@ -28,7 +28,7 @@ pub async fn new() -> NewPage {
 pub struct CreateParams {
     pub username: String,
     pub email: String,
-    pub password: Secret<String>,
+    pub password: SecretString,
     pub invite_code: String,
 }
 
@@ -168,9 +168,9 @@ pub async fn settings(session: Session, State(db): State<Database>) -> Result<im
 
 #[derive(Clone, Deserialize)]
 pub struct ChangePasswordParams {
-    pub old_password: Secret<String>,
-    pub new_password: Secret<String>,
-    pub new_password_confirm: Secret<String>,
+    pub old_password: SecretString,
+    pub new_password: SecretString,
+    pub new_password_confirm: SecretString,
 }
 
 pub async fn change_password(

--- a/src/views/sessions/new.rs
+++ b/src/views/sessions/new.rs
@@ -1,26 +1,15 @@
 use crate::controllers::sessions_controller::CreateParams;
 use crate::models::session::Session;
 use askama_axum::Template;
-use secrecy::{ExposeSecret, Secret};
+use secrecy::{ExposeSecret, SecretString};
 
-#[derive(Clone, Debug, Template)]
+#[derive(Clone, Debug, Default, Template)]
 #[template(path = "sessions/new.html")]
 pub struct NewPage {
     pub session: Option<Session>,
     pub email: String,
-    pub password: Secret<String>,
+    pub password: SecretString,
     pub error_message: Option<String>,
-}
-
-impl Default for NewPage {
-    fn default() -> Self {
-        Self {
-            session: None,
-            email: String::default(),
-            password: Secret::new(String::default()),
-            error_message: Option::default(),
-        }
-    }
 }
 
 impl From<CreateParams> for NewPage {

--- a/src/views/users/new.rs
+++ b/src/views/users/new.rs
@@ -1,9 +1,9 @@
 use crate::controllers::users_controller::CreateParams;
 use crate::models::session::Session;
 use askama_axum::Template;
-use secrecy::{ExposeSecret, Secret};
+use secrecy::{ExposeSecret, SecretString};
 
-#[derive(Clone, Debug, Template)]
+#[derive(Clone, Debug, Default, Template)]
 #[template(path = "users/new.html")]
 pub struct NewPage {
     pub session: Option<Session>,
@@ -11,26 +11,10 @@ pub struct NewPage {
     pub username_error_message: Option<String>,
     pub email: String,
     pub email_error_message: Option<String>,
-    pub password: Secret<String>,
+    pub password: SecretString,
     pub password_error_message: Option<String>,
     pub invite_code: String,
     pub invite_code_error_message: Option<String>,
-}
-
-impl Default for NewPage {
-    fn default() -> Self {
-        Self {
-            session: None,
-            username: String::default(),
-            username_error_message: Option::default(),
-            email: String::default(),
-            email_error_message: Option::default(),
-            password: Secret::new(String::default()),
-            password_error_message: Option::default(),
-            invite_code: String::default(),
-            invite_code_error_message: Option::default(),
-        }
-    }
 }
 
 impl From<CreateParams> for NewPage {
@@ -80,20 +64,11 @@ impl From<CreateParams> for EmailInputPartial {
 }
 
 // TODO: replace this partial with a block fragment once askama 0.13.0 releases
-#[derive(Clone, Debug, Template)]
+#[derive(Clone, Debug, Default, Template)]
 #[template(path = "users/partials/password_input.html")]
 pub struct PasswordInputPartial {
-    pub password: Secret<String>,
+    pub password: SecretString,
     pub password_error_message: Option<String>,
-}
-
-impl Default for PasswordInputPartial {
-    fn default() -> Self {
-        Self {
-            password: Secret::new(String::default()),
-            password_error_message: Option::default(),
-        }
-    }
 }
 
 impl From<CreateParams> for PasswordInputPartial {

--- a/src/views/users/settings.rs
+++ b/src/views/users/settings.rs
@@ -3,7 +3,7 @@ use crate::helpers::view_helper::filters;
 use crate::models::api_session::ApiKey;
 use crate::models::session::Session;
 use askama_axum::Template;
-use secrecy::{ExposeSecret, Secret};
+use secrecy::{ExposeSecret, SecretString};
 
 #[derive(Default, Template)]
 #[template(path = "users/settings.html")]
@@ -14,28 +14,15 @@ pub struct SettingsPage {
 }
 
 // TODO: replace this partial with a block fragment once askama 0.13.0 releases
-#[derive(Clone, Debug, Template)]
+#[derive(Clone, Debug, Default, Template)]
 #[template(path = "users/partials/change_password_form.html")]
 pub struct ChangePasswordFormPartial {
-    pub old_password: Secret<String>,
-    pub new_password: Secret<String>,
-    pub new_password_confirm: Secret<String>,
+    pub old_password: SecretString,
+    pub new_password: SecretString,
+    pub new_password_confirm: SecretString,
     pub old_password_error_message: Option<String>,
     pub new_password_error_message: Option<String>,
     pub show_success_message: bool,
-}
-
-impl Default for ChangePasswordFormPartial {
-    fn default() -> Self {
-        Self {
-            old_password: Secret::new(String::default()),
-            old_password_error_message: Option::default(),
-            new_password: Secret::new(String::default()),
-            new_password_error_message: Option::default(),
-            new_password_confirm: Secret::new(String::default()),
-            show_success_message: bool::default(),
-        }
-    }
 }
 
 impl From<ChangePasswordParams> for ChangePasswordFormPartial {


### PR DESCRIPTION
The major breaking change here is that `Secret` was removed and instead replaced by `SecretBox` and `SecretString`. So the upgrade required a bunch of type changes and coercions of various sorts to get everything working again.