### PR TITLE
Upgrade thiserror crate from v1.0.61 -> 2.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,7 +728,7 @@ dependencies = [
  "serde",
  "sha2",
  "syntect",
- "thiserror",
+ "thiserror 2.0.11",
  "tokio",
  "tokio-rusqlite",
  "tower-http",
@@ -2029,7 +2029,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "walkdir",
  "yaml-rust",
 ]
@@ -2075,7 +2075,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -2083,6 +2092,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ secrecy = { version = "0.10.3", features = ["serde"] }
 serde = { version = "1.0.209", features = ["derive"] }
 sha2 = "0.10.8"
 syntect = "5.2.0"
-thiserror = "1.0.61"
+thiserror = "2.0.11"
 tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread", "signal"] }
 tokio-rusqlite = "0.5.1"
 tower-http = { version = "0.5.2", features = ["compression-full", "timeout", "trace"] }


### PR DESCRIPTION
None of the breaking changes across these versions affect our usage of the crate.