### PR TITLE
Upgrade sqlite crates in tandem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,9 +1143,9 @@ checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.28.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1690,9 +1690,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
  "bitflags 2.8.0",
  "fallible-iterator",
@@ -1705,9 +1705,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite_migration"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55709bc01054c69e2f1cefdc886642b5e6376a8db3c86f761be0c423eebf178b"
+checksum = "923b42e802f7dc20a0a6b5e097ba7c83fe4289da07e49156fecf6af08aa9cd1c"
 dependencies = [
  "log",
  "rusqlite",
@@ -2200,9 +2200,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rusqlite"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2cc5f712424f089fc6549afe39773e9f8914ce170c45b546be24830b482b127"
+checksum = "b65501378eb676f400c57991f42cbd0986827ab5c5200c53f206d710fb32a945"
 dependencies = [
  "crossbeam-channel",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,15 +24,15 @@ jiff = { version = "0.1.12", features = ["serde"] }
 memory-serve = "0.6.0"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
-rusqlite = { version = "0.31.0", features = ["bundled", "uuid"] }
-rusqlite_migration = { version = "1.2.0", features = ["alpha-async-tokio-rusqlite"] }
+rusqlite = { version = "0.32.0", features = ["bundled", "uuid"] }
+rusqlite_migration = { version = "1.3.1", features = ["alpha-async-tokio-rusqlite"] }
 secrecy = { version = "0.10.3", features = ["serde"] }
 serde = { version = "1.0.209", features = ["derive"] }
 sha2 = "0.10.8"
 syntect = "5.2.0"
 thiserror = "2.0.11"
 tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread", "signal"] }
-tokio-rusqlite = "0.5.1"
+tokio-rusqlite = "0.6.0"
 tower-http = { version = "0.5.2", features = ["compression-full", "timeout", "trace"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }


### PR DESCRIPTION
`rusqlite-migration` and `tokio-rusqlite` both require a specific version of `rusqlite` so this bumps the versions for these three crates in tandem.

Note that the latest version of `rusqlite` is actually v0.33.0, but the other two crates are pinned to v0.32.0 so we can't go all the way there yet.